### PR TITLE
feat: add core notification loop implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.stack
-          key: stack-global-${{ hashFiles('stack.yaml') }}
-          restore-keys: stack-global-
-
-      - uses: actions/cache@v3
-        with:
-          path: .stack-work
-          key: stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
-          restore-keys: stack-work-
+      - uses: freckle/stack-cache-action@v2
 
       - uses: haskell/actions/setup@v2
         with:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,4 +3,4 @@ module Main (main) where
 import NMonad
 
 main :: IO ()
-main = nmonad
+main = nmonad def

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Lib
+import NMonad
 
 main :: IO ()
-main = someFunc
+main = nmonad

--- a/nmonad.cabal
+++ b/nmonad.cabal
@@ -65,15 +65,18 @@ test-suite nmonad-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.NMonad
       Paths_nmonad
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -Wno-orphans -Wno-missing-export-lists
   build-depends:
-      base >=4.7 && <5
+      QuickCheck ==2.*
+    , base >=4.7 && <5
     , containers >=0.6.7 && <1
     , data-default >=0.7.1.1 && <1
     , dbus >=1.0.1 && <2
+    , hspec ==2.*
     , mtl >=2.2 && <3
     , nmonad
     , text ==2.*

--- a/nmonad.cabal
+++ b/nmonad.cabal
@@ -65,6 +65,7 @@ test-suite nmonad-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      NMonad.CoreSpec
       Test.NMonad
       Paths_nmonad
   hs-source-dirs:

--- a/nmonad.cabal
+++ b/nmonad.cabal
@@ -26,7 +26,6 @@ source-repository head
 
 library
   exposed-modules:
-      Lib
       NMonad
       NMonad.Core
       NMonad.DBus

--- a/nmonad.cabal
+++ b/nmonad.cabal
@@ -27,6 +27,10 @@ source-repository head
 library
   exposed-modules:
       Lib
+      NMonad
+      NMonad.Core
+      NMonad.DBus
+      NMonad.Main
   other-modules:
       Paths_nmonad
   hs-source-dirs:
@@ -34,6 +38,11 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
+    , containers >=0.6.7 && <1
+    , data-default >=0.7.1.1 && <1
+    , dbus >=1.0.1 && <2
+    , mtl >=2.2 && <3
+    , text ==2.*
   default-language: Haskell2010
 
 executable nmonad
@@ -45,7 +54,12 @@ executable nmonad
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers >=0.6.7 && <1
+    , data-default >=0.7.1.1 && <1
+    , dbus >=1.0.1 && <2
+    , mtl >=2.2 && <3
     , nmonad
+    , text ==2.*
   default-language: Haskell2010
 
 test-suite nmonad-test
@@ -58,5 +72,10 @@ test-suite nmonad-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers >=0.6.7 && <1
+    , data-default >=0.7.1.1 && <1
+    , dbus >=1.0.1 && <2
+    , mtl >=2.2 && <3
     , nmonad
+    , text ==2.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,11 @@ description:         Please see the README on GitHub at <https://github.com/d3ad
 
 dependencies:
 - base >= 4.7 && < 5
+- mtl >= 2.2 && < 3
+- text == 2.*
+- dbus >= 1.0.1 && < 2
+- containers >= 0.6.7 && < 1
+- data-default >= 0.7.1.1 && < 1
 
 ghc-options:
 - -Wall

--- a/package.yaml
+++ b/package.yaml
@@ -15,11 +15,11 @@ description:         Please see the README on GitHub at <https://github.com/d3ad
 
 dependencies:
 - base >= 4.7 && < 5
-- mtl >= 2.2 && < 3
-- text == 2.*
-- dbus >= 1.0.1 && < 2
 - containers >= 0.6.7 && < 1
 - data-default >= 0.7.1.1 && < 1
+- dbus >= 1.0.1 && < 2
+- mtl >= 2.2 && < 3
+- text == 2.*
 
 ghc-options:
 - -Wall

--- a/package.yaml
+++ b/package.yaml
@@ -54,5 +54,9 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -Wno-orphans
+    - -Wno-missing-export-lists
     dependencies:
+    - QuickCheck == 2.*
+    - hspec == 2.*
     - nmonad

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,0 @@
-module Lib
-    ( someFunc
-    ) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/src/NMonad.hs
+++ b/src/NMonad.hs
@@ -1,0 +1,7 @@
+module NMonad
+  ( module NMonad.Core
+  , module NMonad.Main
+  ) where
+
+import NMonad.Core
+import NMonad.Main

--- a/src/NMonad/Core.hs
+++ b/src/NMonad/Core.hs
@@ -28,6 +28,12 @@ import Data.Text (Text)
 import Data.Word
 import DBus (Variant)
 
+-- | The 'N' monad, 'ReaderT' and 'StateT' transformers over 'IO', encapsulating the daemon's read-only environment and
+-- state, respectively.
+--
+-- State can be retrieved with 'get', while read-only configuration can be retrieved with 'ask'. These are a result of
+-- deriving the 'MonadReader' and 'MonadState' typeclasses.
+--
 newtype N a = N (ReaderT NEnv (StateT NState IO) a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadReader NEnv, MonadState NState)
 
@@ -49,9 +55,10 @@ instance Default NConfig where
     , disableReplacement = False
     }
 
+-- | The mutable state of the daemon.
 data NState = NState
-  { notificationCount :: Int
-  , notifications :: [Notification]
+  { notificationCount :: Int        -- ^ Counter for notification IDs.
+  , notifications :: [Notification] -- ^ List of received notifications.
   } deriving (Show)
 
 instance Default NState where
@@ -70,12 +77,10 @@ fromTimeout n
 --
 -- The desktop notifications specification can be found in the following URL:
 --   https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+--
 data DBusNotification = DBusNotification Text Word32 Text Text Text [Text] (Map Text Variant) Int32
 
 -- | A notification sent by some application and processed by NMonad.
---
--- The desktop notifications specification can be found in the following URL:
---   https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
 data Notification = Notification
   { applicationName :: Text   -- ^ Name of the application sending the notification.
   , applicationIcon :: Text   -- ^ Icon for the application sending the notification.
@@ -83,7 +88,7 @@ data Notification = Notification
   , body :: Text              -- ^ The optional detailed body text.
   , identifier :: Word32      -- ^ Unsigned integer ID for the notification.
   , actions :: [Text]         -- ^ A list of actions (buttons) associated with the notification.
-  , hints :: Map Text Variant -- ^ A dictionary of extra data to pass along with the notification.
+  , hints :: Map Text Variant -- ^ A dictionary of hints passed along with the notification.
   , timeout :: Expiration     -- ^ When the notification should expire.
   } deriving (Show)
 

--- a/src/NMonad/Core.hs
+++ b/src/NMonad/Core.hs
@@ -114,7 +114,6 @@ notificationFromDBus (DBusNotification appName replacesId appIcon summ bod acts 
 addToNotificationsAndReturnId :: Notification -> N Word32
 addToNotificationsAndReturnId n = do
   modify $ \s -> s { notifications = n : notifications s }
-  get >>= liftIO . print
   return $ identifier n
 
 -- | Run the 'N' monad.

--- a/src/NMonad/Core.hs
+++ b/src/NMonad/Core.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module NMonad.Core
+  ( N(..)
+  , NConf(..)
+  , NState(..)
+  , Expiration(..)
+  , DBusNotification(..)
+  , Notification(..)
+
+  , notificationFromDBus
+  , addToNotificationsAndReturnId
+  , runN
+
+  , module Control.Monad.Reader
+  , module Control.Monad.State
+  , module Data.Default
+  ) where
+
+import Control.Concurrent (MVar)
+import Control.Monad.Reader
+import Control.Monad.State
+
+import Data.Default
+import Data.Int (Int32)
+import Data.Map (Map)
+import Data.Text (Text)
+import Data.Word
+import DBus (Variant)
+
+newtype N a = N (ReaderT NConf (StateT NState IO) a)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadReader NConf, MonadState NState)
+
+data NConf = NConf
+  { sleepSeconds :: Int
+  , sleepMessage :: String
+  , dbusMethodCall :: MVar (DBusNotification, MVar Word32)
+  }
+
+data NState = NState
+  { notificationCount :: Int
+  , notifications :: [Notification]
+  } deriving (Show)
+
+instance Default NState where
+  def = NState 0 []
+
+-- | Helper data type to represent when a given notification should expire.
+data Expiration = ServerDefault | Never | Milliseconds Int32 deriving (Show)
+
+fromTimeout :: Int32 -> Expiration
+fromTimeout n
+  | n < 0 = ServerDefault
+  | n == 0 = Never
+  | otherwise = Milliseconds n
+
+-- | Raw notification data received from DBus.
+--
+-- The desktop notifications specification can be found in the following URL:
+--   https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+data DBusNotification = DBusNotification Text Word32 Text Text Text [Text] (Map Text Variant) Int32
+
+-- | A notification sent by some application and processed by NMonad.
+--
+-- The desktop notifications specification can be found in the following URL:
+--   https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+data Notification = Notification
+  { applicationName :: Text   -- ^ Name of the application sending the notification.
+  , applicationIcon :: Text   -- ^ Icon for the application sending the notification.
+  , summary :: Text           -- ^ A brief one-line summary of the notification.
+  , body :: Text              -- ^ The optional detailed body text.
+  , identifier :: Word32      -- ^ Unsigned integer ID for the notification.
+  , actions :: [Text]         -- ^ A list of actions (buttons) associated with the notification.
+  , hints :: Map Text Variant -- ^ A dictionary of extra data to pass along with the notification.
+  , timeout :: Expiration     -- ^ When the notification should expire.
+  } deriving (Show)
+
+instance Default Notification where
+  def = Notification mempty mempty mempty mempty 0 mempty mempty ServerDefault
+
+-- | Produces a Notification given the data provided by DBus.
+notificationFromDBus :: DBusNotification -> N Notification
+notificationFromDBus (DBusNotification appName replacesId appIcon summ bod acts hnts tout) = do
+  newNotificationId <- gets notificationCount
+  when (replacesId == 0) $ modify $ \s -> s { notificationCount = newNotificationId + 1 }
+  return def
+    { applicationName = appName
+    , identifier = if replacesId == 0 then fromIntegral newNotificationId else replacesId
+    , applicationIcon = appIcon
+    , summary = summ
+    , body = bod
+    , actions = acts
+    , hints = hnts
+    , timeout = fromTimeout tout
+    }
+
+addToNotificationsAndReturnId :: Notification -> N Word32
+addToNotificationsAndReturnId n = do
+  modify $ \s -> s { notifications = n : notifications s }
+  get >>= liftIO . print
+  return $ identifier n
+
+-- | Run the 'N' monad.
+runN :: NConf -> NState -> N a -> IO (a, NState)
+runN c s (N n) = runStateT (runReaderT n c) s

--- a/src/NMonad/Core.hs
+++ b/src/NMonad/Core.hs
@@ -98,8 +98,8 @@ instance Default Notification where
 -- | Produces a Notification given the data provided by DBus.
 notificationFromDBus :: DBusNotification -> N Notification
 notificationFromDBus (DBusNotification appName replacesId appIcon summ bod acts hnts tout) = do
-  newNotificationId <- gets notificationCount
-  when (replacesId == 0) $ modify $ \s -> s { notificationCount = newNotificationId + 1 }
+  newNotificationId <- gets $ (+1) . notificationCount
+  when (replacesId == 0) $ modify $ \s -> s { notificationCount = newNotificationId }
   return def
     { applicationName = appName
     , identifier = if replacesId == 0 then fromIntegral newNotificationId else replacesId

--- a/src/NMonad/DBus.hs
+++ b/src/NMonad/DBus.hs
@@ -16,6 +16,7 @@ import Paths_nmonad (version)
 
 import NMonad.Core
 
+-- | Helper function to create an AutoMethod from a function that accepts a 'DBusNotification'.
 withDBusNotification
   :: (DBusNotification -> a) -- ^ Function that accepts a DBusNotification.
   -> Text                    -- ^ Name of the application sending the notification.
@@ -48,6 +49,17 @@ serverInformation = return ("NMonad", "NMonad", pack $ showVersion version, "1.2
 capabilities :: IO [Text]
 capabilities = return ["body", "body-markup", "icon-static"]
 
+-- | Connect to DBus, request the org.freedesktop.Notifications name and export the appropriate interface at
+-- /org/freedesktop/Notifications.
+--
+-- Requires an 'MVar' to for synchronization with the main thread. The 'MVar' is used to pass the notification data
+-- received from DBus to the main thread, as well as a reference to a new 'MVar' that will be populated with the
+-- 'Word32' representing the ID of the sent notification. Refer to the Desktop Notifications Specification for more
+-- information.
+--
+-- This action starts a new thread due to calling 'connectSession', and so it doesn't block the thread that
+-- invoked it.
+--
 listenForNotifications :: MVar (DBusNotification, MVar Word32) -> IO ()
 listenForNotifications syncVar = do
   putStrLn "Connecting to DBus to create client..."

--- a/src/NMonad/DBus.hs
+++ b/src/NMonad/DBus.hs
@@ -6,10 +6,13 @@ module NMonad.DBus
 import Control.Concurrent
 import Data.Int (Int32)
 import Data.Map (Map)
-import Data.Text (Text)
+import Data.Text (Text, pack)
 import Data.Word (Word32)
 import DBus.Client
 import DBus (Variant)
+
+import Data.Version (showVersion)
+import Paths_nmonad (version)
 
 import NMonad.Core
 
@@ -39,7 +42,7 @@ receiveNotification syncVar dn = do
 
 -- | Server information exposed to DBus as GetServerInformation().
 serverInformation :: IO (Text, Text, Text, Text)
-serverInformation = return ("NMonad", "NMonad", "0.1", "1.2")
+serverInformation = return ("NMonad", "NMonad", pack $ showVersion version, "1.2")
 
 -- | Capability information exposed to DBus as GetCapabilities().
 capabilities :: IO [Text]

--- a/src/NMonad/DBus.hs
+++ b/src/NMonad/DBus.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+module NMonad.DBus
+  ( listenForNotifications
+  ) where
+
+import Control.Concurrent
+import Data.Int (Int32)
+import Data.Map (Map)
+import Data.Text (Text)
+import Data.Word (Word32)
+import DBus.Client
+import DBus (Variant)
+
+import NMonad.Core
+
+withDBusNotification
+  :: (DBusNotification -> a) -- ^ Function that accepts a DBusNotification.
+  -> Text                    -- ^ Name of the application sending the notification.
+  -> Word32                  -- ^ ID of the notification to be replaced, if any.
+  -> Text                    -- ^ Icon to be displayed in the notification.
+  -> Text                    -- ^ Summary of the notification.
+  -> Text                    -- ^ Body of the notification.
+  -> [Text]                  -- ^ Actions to be displayed in the notification.
+  -> Map Text Variant        -- ^ Hints for the notification.
+  -> Int32                   -- ^ Timeout for the notification.
+  -> a
+withDBusNotification = (........ DBusNotification)
+  where (........) = (.) . (.) . (.) . (.) . (.) . (.) . (.) . (.)
+
+-- | Receives a notification from DBus and places it in the global MVar.
+receiveNotification
+  :: MVar (DBusNotification, MVar Word32) -- ^ MVar to place notification data and new MVar.
+  -> DBusNotification                     -- ^ Raw notification data received from DBus.
+  -> IO Word32                            -- ^ Yields the ID of the sent notification.
+receiveNotification syncVar dn = do
+  notificationId <- newEmptyMVar
+  putMVar syncVar (dn, notificationId)
+  takeMVar notificationId
+
+-- | Server information exposed to DBus as GetServerInformation().
+serverInformation :: IO (Text, Text, Text, Text)
+serverInformation = return ("NMonad", "NMonad", "0.1", "1.2")
+
+-- | Capability information exposed to DBus as GetCapabilities().
+capabilities :: IO [Text]
+capabilities = return ["body", "body-markup", "icon-static"]
+
+listenForNotifications :: MVar (DBusNotification, MVar Word32) -> IO ()
+listenForNotifications syncVar = do
+  putStrLn "Connecting to DBus to create client..."
+  client <- connectSession
+
+  putStrLn "Requesting the org.freedesktop.Notifications name..."
+  reply <- requestName client "org.freedesktop.Notifications" [nameAllowReplacement, nameReplaceExisting]
+  putStrLn $ "Reply: " ++ show reply
+  when (reply /= NamePrimaryOwner) $
+    fail ("Failed to become primary owner of org.freedesktop.Notifications: " ++ show reply)
+
+  export client "/org/freedesktop/Notifications" defaultInterface
+    { interfaceName = "org.freedesktop.Notifications"
+    , interfaceMethods =
+      [ autoMethod "GetServerInformation" serverInformation
+      , autoMethod "GetCapabilities" capabilities
+      , autoMethod "Notify" (withDBusNotification $ receiveNotification syncVar)
+      ]
+    }

--- a/src/NMonad/Main.hs
+++ b/src/NMonad/Main.hs
@@ -1,0 +1,19 @@
+module NMonad.Main (nmonad) where
+
+import Control.Concurrent
+import NMonad.Core
+import NMonad.DBus
+
+nmonad :: IO ()
+nmonad = do
+  syncVar <- newEmptyMVar
+  listenForNotifications syncVar
+  let conf = NConf 60 "Sleeping for 60 seconds..." syncVar
+  _ <- runN conf def mainLoop
+  return ()
+
+mainLoop :: N ()
+mainLoop = forever $ do
+  (dbusNotification, responseVar) <- asks dbusMethodCall >>= liftIO . takeMVar
+  notification <- notificationFromDBus dbusNotification
+  addToNotificationsAndReturnId notification >>= liftIO . putMVar responseVar

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.7
+resolver: lts-21.12
 
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 23bb9bb355bfdb1635252e120a29b712f0d5e8a6c6a65c5ab5bd6692f46c438e
-    size: 640457
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/7.yaml
-  original: lts-21.7
+    sha256: 9313df78f49519315342f4c51ffc5da12659d3735f8ac3c54a1fb98ff874474e
+    size: 640036
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/12.yaml
+  original: lts-21.12

--- a/test/NMonad/CoreSpec.hs
+++ b/test/NMonad/CoreSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+module NMonad.CoreSpec (spec) where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Test.NMonad
+
+import NMonad.Core
+
+deriving instance Show DBusNotification
+deriving instance Eq Expiration
+deriving instance Eq Notification
+
+spec :: Spec
+spec = do
+  describe "notificationFromDBus :: DBusNotification -> N Notification" $ do
+    prop "respects replacesId if set to something other than 0" $ \dbusnotif -> do
+      replacesId <- generate $ arbitrary `suchThat` (/= 0)
+      let (DBusNotification an _ ai s b a h t) = dbusnotif
+          dbusnotif' = DBusNotification an replacesId ai s b a h t
+      (notification, _, _) <- runGenN $ notificationFromDBus dbusnotif'
+      identifier notification `shouldBe` replacesId
+
+    prop "generates some notification id when replacesId is 0" $ \dbusnotif -> do
+      let (DBusNotification an _ ai s b a h t) = dbusnotif
+          dbusnotif' = DBusNotification an 0 ai s b a h t
+      (notification, finalState, (_, initialState)) <- runGenN $ notificationFromDBus dbusnotif'
+      identifier notification `shouldNotBe` 0
+      notificationCount finalState `shouldBe` 1 + notificationCount initialState
+
+  describe "addToNotificationsAndReturnId :: Notification -> N Word32" $ do
+    prop "adds the notification to the state and returns its identifier" $ \notif -> do
+      (returnedId, finalState, (_, initialState)) <- runGenN $ addToNotificationsAndReturnId notif
+      notif `shouldNotSatisfy` (`elem` notifications initialState)
+      notif `shouldSatisfy` (`elem` notifications finalState)
+      identifier notif `shouldBe` returnedId

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/Test/NMonad.hs
+++ b/test/Test/NMonad.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Test.NMonad where
+
+import Control.Concurrent (newEmptyMVar)
+import Data.Map (empty)
+import Data.Text (pack, Text)
+import System.IO.Unsafe (unsafePerformIO)
+
+import Test.QuickCheck
+
+import NMonad.Core
+
+instance Arbitrary Text where
+  arbitrary = fmap pack arbitrary
+
+instance Arbitrary a => Arbitrary (N a) where
+  arbitrary = fmap pure arbitrary
+
+instance Arbitrary NEnv where
+  arbitrary = NEnv (unsafePerformIO newEmptyMVar) <$> arbitrary
+
+instance Arbitrary NConfig where
+  arbitrary = do
+    defaultTimeout <- arbitrary
+    disableReplacement <- arbitrary
+    return NConfig {..}
+
+instance Arbitrary NState where
+  arbitrary = do
+    notificationCount <- getSize
+    notifications <- arbitrary
+    return NState {..}
+
+instance Arbitrary Notification where
+  arbitrary = do
+    applicationName <- arbitrary
+    applicationIcon <- arbitrary
+    summary <- arbitrary
+    body <- arbitrary
+    identifier <- arbitrary
+    actions <- arbitrary
+    timeout <- arbitrary
+    return Notification {hints = empty, ..}
+
+instance Arbitrary Expiration where
+  arbitrary = do
+    randomMilliseconds <- arbitrary
+    elements [ServerDefault, Never, Milliseconds randomMilliseconds]
+
+instance Arbitrary DBusNotification where
+  arbitrary = DBusNotification <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> pure empty <*> arbitrary
+
+-- | Run an action in the 'N' monad with a generated initial environment and state.
+runGenN :: N a -> IO (a, NState, (NEnv, NState))
+runGenN action = do
+  initialEnvironment <- generate arbitrary
+  initialState <- generate arbitrary
+  (wrapped, finalState) <- runN initialEnvironment initialState action
+  return (wrapped, finalState, (initialEnvironment, initialState))


### PR DESCRIPTION
Add project core code that acts as a proof of concept for the time being.

Additionally, adopt [freckle/stack-cache-action](https://github.com/freckle/stack-cache-action) in place of the `actions/cache` stanzas that were previously in place.